### PR TITLE
feat: [FW-86] Create new POST endpoint in API to create a new playlist

### DIFF
--- a/src/entities/playlists.ts
+++ b/src/entities/playlists.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 export type CreateNewPlaylistDTO = {
   playlist: {
     name: string;
@@ -9,13 +11,14 @@ export type CreateNewPlaylistDTO = {
   }>;
 };
 
-export type CreateNewPlaylistStatusType =
-  | 'CREATED_WITHOUT_ISSUES'
-  | 'CREATED_MISSING_ARTISTS';
+export enum CreatedPlaylistStatus {
+  OK = 'OK',
+  MISSING_ARTISTS = 'MISSING_ARTISTS',
+}
 
 export type CreateNewPlaylistResponseDTO = {
   id: string;
-  status: CreateNewPlaylistStatusType;
+  status: CreatedPlaylistStatus;
 };
 
 export type UpdatePlaylistDTO = {

--- a/src/entities/playlists.ts
+++ b/src/entities/playlists.ts
@@ -9,8 +9,13 @@ export type CreateNewPlaylistDTO = {
   }>;
 };
 
+export type CreateNewPlaylistStatusType =
+  | 'CREATED_WITHOUT_ISSUES'
+  | 'CREATED_MISSING_ARTISTS';
+
 export type CreateNewPlaylistResponseDTO = {
   id: string;
+  status: CreateNewPlaylistStatusType;
 };
 
 export type UpdatePlaylistDTO = {

--- a/src/entities/playlists.ts
+++ b/src/entities/playlists.ts
@@ -4,7 +4,7 @@ export type CreateNewPlaylistDTO = {
   playlist: {
     name: string;
     description?: string | undefined;
-    isPrivate: boolean;
+    isPublic: boolean;
   };
   artists: Array<{
     name: string;

--- a/src/entities/playlists.ts
+++ b/src/entities/playlists.ts
@@ -1,7 +1,16 @@
 export type CreateNewPlaylistDTO = {
-  name: string;
-  isPrivate: boolean;
-  artists: string[];
+  playlist: {
+    name: string;
+    description?: string | undefined;
+    isPrivate: boolean;
+  };
+  artists: Array<{
+    name: string;
+  }>;
+};
+
+export type CreateNewPlaylistResponseDTO = {
+  id: string;
 };
 
 export type UpdatePlaylistDTO = {

--- a/src/lib/clients/http.ts
+++ b/src/lib/clients/http.ts
@@ -1,7 +1,9 @@
+/* eslint-disable no-unused-vars */
 import axios from 'axios';
 
 export enum Method {
-  Get = 'GET', // eslint-disable-line no-unused-vars
+  Get = 'GET',
+  Post = 'POST',
 }
 
 export interface HttpRequest {
@@ -9,6 +11,7 @@ export interface HttpRequest {
   method: Method;
   params?: Record<string, any>;
   headers?: Record<string, string>;
+  data?: Record<string, any>;
 }
 
 export interface HttpClient {
@@ -26,12 +29,14 @@ export class HttpBaseClient implements HttpClient {
     method,
     params,
     headers,
+    data,
   }: HttpRequest): Promise<HttpResponse> {
     return axios({
       url,
       method,
       params,
       headers,
+      data,
     }).then((response) => {
       return {
         data: response.data,

--- a/src/lib/clients/playlists.test.ts
+++ b/src/lib/clients/playlists.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { CreateNewPlaylistDTO, Playlist } from '@/entities/playlists';
+import {
+  CreatedPlaylistStatus,
+  CreateNewPlaylistDTO,
+  Playlist,
+} from '@/entities/playlists';
 import { PlaylistsHTTPClient } from './playlists';
 import { FakeHttpClient, HttpResponse, Method } from './http';
 import { AuthHeaderBuilderStub, AuthHeaderBuilder } from './auth';
@@ -171,7 +175,7 @@ describe('PlaylistsHTTPClient', () => {
 
       const expectedResponse = {
         id: response.data.playlist.id,
-        status: 'CREATED_WITHOUT_ISSUES',
+        status: CreatedPlaylistStatus.OK,
       };
       expect(result).toEqual(expectedResponse);
     });
@@ -188,7 +192,7 @@ describe('PlaylistsHTTPClient', () => {
 
       const expectedResponse = {
         id: response.data.playlist.id,
-        status: 'CREATED_MISSING_ARTISTS',
+        status: CreatedPlaylistStatus.MISSING_ARTISTS,
       };
       expect(result).toEqual(expectedResponse);
     });

--- a/src/lib/clients/playlists.test.ts
+++ b/src/lib/clients/playlists.test.ts
@@ -163,39 +163,28 @@ describe('PlaylistsHTTPClient', () => {
       });
     });
 
-    it('should return the response data from the HTTP client without issues when the status is 201', async () => {
-      mockHttpClientResponse();
-      const client = new PlaylistsHTTPClient(
-        url,
-        httpClient,
-        authHeaderBuilder
-      );
+    it.each([
+      { status: 201, expectedStatus: CreatedPlaylistStatus.OK },
+      { status: 207, expectedStatus: CreatedPlaylistStatus.MISSING_ARTISTS },
+    ])(
+      'should return the response data with the correct status when HTTP status is $status',
+      async ({ status, expectedStatus }) => {
+        mockHttpClientResponse(status);
+        const client = new PlaylistsHTTPClient(
+          url,
+          httpClient,
+          authHeaderBuilder
+        );
 
-      const result = await client.createPlaylist(token, playlistData);
+        const result = await client.createPlaylist(token, playlistData);
 
-      const expectedResponse = {
-        id: response.data.playlist.id,
-        status: CreatedPlaylistStatus.OK,
-      };
-      expect(result).toEqual(expectedResponse);
-    });
-
-    it('should return the response data from the HTTP client with missing artists when the status is 207', async () => {
-      mockHttpClientResponse(207);
-      const client = new PlaylistsHTTPClient(
-        url,
-        httpClient,
-        authHeaderBuilder
-      );
-
-      const result = await client.createPlaylist(token, playlistData);
-
-      const expectedResponse = {
-        id: response.data.playlist.id,
-        status: CreatedPlaylistStatus.MISSING_ARTISTS,
-      };
-      expect(result).toEqual(expectedResponse);
-    });
+        const expectedResponse = {
+          id: response.data.playlist.id,
+          status: expectedStatus,
+        };
+        expect(result).toEqual(expectedResponse);
+      }
+    );
 
     it('should throw an error if the HTTP client fails', async () => {
       mockHttpClientResponse();

--- a/src/lib/clients/playlists.test.ts
+++ b/src/lib/clients/playlists.test.ts
@@ -124,7 +124,7 @@ describe('PlaylistsHTTPClient', () => {
         playlist: {
           name: 'Festival Hits',
           description: 'All the best songs',
-          isPrivate: false,
+          isPublic: false,
         },
         artists: [{ name: 'Artist 1' }, { name: 'Artist 2' }],
       };

--- a/src/lib/clients/playlists.test.ts
+++ b/src/lib/clients/playlists.test.ts
@@ -1,91 +1,198 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { Playlist } from '@/entities/playlists';
+import { CreateNewPlaylistDTO, Playlist } from '@/entities/playlists';
 import { PlaylistsHTTPClient } from './playlists';
 import { FakeHttpClient, HttpResponse, Method } from './http';
 import { AuthHeaderBuilderStub, AuthHeaderBuilder } from './auth';
 
 describe('PlaylistsHTTPClient', () => {
-  let url: string;
-  let token: string;
-  let name: string;
-  let limit: number;
-  let httpClient: FakeHttpClient;
-  let response: HttpResponse;
-  let authHeaderBuilder: AuthHeaderBuilder;
+  describe('searchPlaylists', () => {
+    let url: string;
+    let token: string;
+    let name: string;
+    let limit: number;
+    let httpClient: FakeHttpClient;
+    let response: HttpResponse;
+    let authHeaderBuilder: AuthHeaderBuilder;
 
-  beforeEach(() => {
-    url = 'http://some_url';
-    token = 'my-token';
-    name = 'Chill';
-    limit = 5;
-    response = {
-      data: [
-        {
-          id: '1',
-          name: 'Chill Vibes',
-          description: 'Some description',
-          isPublic: true,
-        },
-        {
-          id: '2',
-          name: 'Chill Hits',
-          description: 'Some description',
-          isPublic: true,
-        },
-      ],
-      status: 200,
-    };
-    httpClient = new FakeHttpClient(response);
-    authHeaderBuilder = new AuthHeaderBuilderStub();
-  });
+    beforeEach(() => {
+      url = 'http://some_url';
+      token = 'my-token';
+      name = 'Chill';
+      limit = 5;
+      response = {
+        data: [
+          {
+            id: '1',
+            name: 'Chill Vibes',
+            description: 'Some description',
+            isPublic: true,
+          },
+          {
+            id: '2',
+            name: 'Chill Hits',
+            description: 'Some description',
+            isPublic: true,
+          },
+        ],
+        status: 200,
+      };
+      httpClient = new FakeHttpClient(response);
+      authHeaderBuilder = new AuthHeaderBuilderStub();
+    });
 
-  it('should call the client with the correct parameters', async () => {
-    const headers = { something: 'value' };
-    const client = new PlaylistsHTTPClient(
-      url,
-      httpClient,
-      new AuthHeaderBuilderStub(headers)
-    );
-    vi.spyOn(httpClient, 'send');
+    it('should call the client with the correct parameters', async () => {
+      const headers = { something: 'value' };
+      const client = new PlaylistsHTTPClient(
+        url,
+        httpClient,
+        new AuthHeaderBuilderStub(headers)
+      );
+      vi.spyOn(httpClient, 'send');
 
-    await client.searchPlaylists(token, name, limit);
+      await client.searchPlaylists(token, name, limit);
 
-    expect(httpClient.send).toHaveBeenCalledWith({
-      url: `${url}/playlists/search`,
-      method: Method.Get,
-      params: { name: name, limit: limit },
-      headers: headers,
+      expect(httpClient.send).toHaveBeenCalledWith({
+        url: `${url}/playlists/search`,
+        method: Method.Get,
+        params: { name: name, limit: limit },
+        headers: headers,
+      });
+    });
+
+    it('should return the list of playlists returned by the HTTP client', async () => {
+      const client = new PlaylistsHTTPClient(
+        url,
+        httpClient,
+        authHeaderBuilder
+      );
+
+      const actual = await client.searchPlaylists(token, name, limit);
+
+      const expected = [
+        new Playlist('1', 'Chill Vibes', true, 'Some description'),
+        new Playlist('2', 'Chill Hits', true, 'Some description'),
+      ];
+      expect(actual).toEqual(expected);
+    });
+
+    it('should throw an error if the HTTP client fails', async () => {
+      const errorMessage = 'Request failed';
+      httpClient.setSendErrorMessage(errorMessage);
+      const client = new PlaylistsHTTPClient(
+        url,
+        httpClient,
+        authHeaderBuilder
+      );
+
+      await expect(client.searchPlaylists(token, name, limit)).rejects.toThrow(
+        errorMessage
+      );
+    });
+
+    it('should throw an error if the header builder fails', async () => {
+      vi.spyOn(authHeaderBuilder, 'buildHeader').mockImplementation(() => {
+        throw new Error('test Error');
+      });
+      const client = new PlaylistsHTTPClient(
+        url,
+        httpClient,
+        authHeaderBuilder
+      );
+
+      await expect(
+        client.searchPlaylists(token, name, limit)
+      ).rejects.toThrow();
     });
   });
 
-  it('should return the list of playlists returned by the HTTP client', async () => {
-    const client = new PlaylistsHTTPClient(url, httpClient, authHeaderBuilder);
+  describe('createPlaylist', () => {
+    let url: string;
+    let token: string;
+    let playlistData: CreateNewPlaylistDTO;
+    let httpClient: FakeHttpClient;
+    let response: HttpResponse;
+    let authHeaderBuilder: AuthHeaderBuilder;
 
-    const actual = await client.searchPlaylists(token, name, limit);
-
-    const expected = [
-      new Playlist('1', 'Chill Vibes', true, 'Some description'),
-      new Playlist('2', 'Chill Hits', true, 'Some description'),
-    ];
-    expect(actual).toEqual(expected);
-  });
-
-  it('should throw an error if the HTTP client fails', async () => {
-    const errorMessage = 'Request failed';
-    httpClient.setSendErrorMessage(errorMessage);
-    const client = new PlaylistsHTTPClient(url, httpClient, authHeaderBuilder);
-
-    await expect(client.searchPlaylists(token, name, limit)).rejects.toThrow(
-      errorMessage
-    );
-  });
-
-  it('should throw an error if the header builder fails', async () => {
-    vi.spyOn(authHeaderBuilder, 'buildHeader').mockImplementation(() => {
-      throw new Error('test Error');
+    beforeEach(() => {
+      url = 'http://some_url';
+      token = 'my-token';
+      playlistData = {
+        playlist: {
+          name: 'Festival Hits',
+          description: 'All the best songs',
+          isPrivate: false,
+        },
+        artists: [{ name: 'Artist 1' }, { name: 'Artist 2' }],
+      };
+      response = {
+        data: {
+          playlist: {
+            id: '123',
+          },
+        },
+        status: 201,
+      };
+      httpClient = new FakeHttpClient(response);
+      authHeaderBuilder = new AuthHeaderBuilderStub();
     });
-    const client = new PlaylistsHTTPClient(url, httpClient, authHeaderBuilder);
 
-    await expect(client.searchPlaylists(token, name, limit)).rejects.toThrow();
+    it('should call the client with the correct parameters', async () => {
+      const headers = { authorization: 'Bearer token' };
+      const client = new PlaylistsHTTPClient(
+        url,
+        httpClient,
+        new AuthHeaderBuilderStub(headers)
+      );
+      vi.spyOn(httpClient, 'send');
+
+      await client.createPlaylist(token, playlistData);
+
+      expect(httpClient.send).toHaveBeenCalledWith({
+        url: `${url}/playlists`,
+        method: Method.Post,
+        data: playlistData,
+        headers: headers,
+      });
+    });
+
+    it('should return the response data returned by the HTTP client', async () => {
+      const client = new PlaylistsHTTPClient(
+        url,
+        httpClient,
+        authHeaderBuilder
+      );
+
+      const result = await client.createPlaylist(token, playlistData);
+      expect(result).toEqual(response.data.playlist);
+    });
+
+    it('should throw an error if the HTTP client fails', async () => {
+      const errorMessage = 'Failed to create playlist';
+      httpClient.setSendErrorMessage(errorMessage);
+      const client = new PlaylistsHTTPClient(
+        url,
+        httpClient,
+        authHeaderBuilder
+      );
+
+      await expect(client.createPlaylist(token, playlistData)).rejects.toThrow(
+        errorMessage
+      );
+    });
+
+    it('should throw an error if the header builder fails', async () => {
+      vi.spyOn(authHeaderBuilder, 'buildHeader').mockImplementation(() => {
+        throw new Error('Authentication failed');
+      });
+      const client = new PlaylistsHTTPClient(
+        url,
+        httpClient,
+        authHeaderBuilder
+      );
+
+      await expect(
+        client.createPlaylist(token, playlistData)
+      ).rejects.toThrow();
+    });
   });
 });

--- a/src/lib/clients/playlists.test.ts
+++ b/src/lib/clients/playlists.test.ts
@@ -222,6 +222,27 @@ describe('PlaylistsHTTPClient', () => {
       );
     });
 
+    it.each([
+      { status: 400, message: 'Bad request' },
+      { status: 500, message: 'Internal error' },
+    ])(
+      'should throw an error if the server response status is not the expected successful one',
+      async ({ status, message }) => {
+        response = { status: status, data: message };
+        httpClient = new FakeHttpClient(response);
+        const client = new PlaylistsHTTPClient(
+          url,
+          httpClient,
+          authHeaderBuilder
+        );
+
+        const expectedMessage = `Unexpected playlist search response status: ${status}: ${message}`;
+        await expect(
+          client.createPlaylist(token, playlistData)
+        ).rejects.toThrow(expectedMessage);
+      }
+    );
+
     it('should throw an error if the header builder fails', async () => {
       mockHttpClientResponse();
       vi.spyOn(authHeaderBuilder, 'buildHeader').mockImplementation(() => {

--- a/src/lib/clients/playlists.ts
+++ b/src/lib/clients/playlists.ts
@@ -84,11 +84,16 @@ export class PlaylistsHTTPClient implements PlaylistsClient {
             id: response.data.playlist.id,
             status: CreatedPlaylistStatus.OK,
           };
+        } else if (response.status === 207) {
+          return {
+            id: response.data.playlist.id,
+            status: CreatedPlaylistStatus.MISSING_ARTISTS,
+          };
+        } else {
+          throw new Error(
+            `Unexpected playlist search response status: ${response.status}: ${response.data}`
+          );
         }
-        return {
-          id: response.data.playlist.id,
-          status: CreatedPlaylistStatus.MISSING_ARTISTS,
-        };
       });
   }
 }

--- a/src/lib/clients/playlists.ts
+++ b/src/lib/clients/playlists.ts
@@ -1,4 +1,5 @@
 import {
+  CreatedPlaylistStatus,
   CreateNewPlaylistDTO,
   CreateNewPlaylistResponseDTO,
   Playlist,
@@ -75,12 +76,12 @@ export class PlaylistsHTTPClient implements PlaylistsClient {
         if (response.status === 201) {
           return {
             id: response.data.playlist.id,
-            status: 'CREATED_WITHOUT_ISSUES',
+            status: CreatedPlaylistStatus.OK,
           };
         }
         return {
           id: response.data.playlist.id,
-          status: 'CREATED_MISSING_ARTISTS',
+          status: CreatedPlaylistStatus.MISSING_ARTISTS,
         };
       });
   }
@@ -94,7 +95,7 @@ export class PlaylistsClientStub implements PlaylistsClient {
     searchPlaylistResult: Playlist[] = [],
     createPlaylistResult: CreateNewPlaylistResponseDTO = {
       id: '1',
-      status: 'CREATED_WITHOUT_ISSUES',
+      status: CreatedPlaylistStatus.OK,
     }
   ) {
     this.searchPlaylistResult = searchPlaylistResult;

--- a/src/lib/clients/playlists.ts
+++ b/src/lib/clients/playlists.ts
@@ -1,4 +1,8 @@
-import { Playlist } from '@/entities/playlists';
+import {
+  CreateNewPlaylistDTO,
+  CreateNewPlaylistResponseDTO,
+  Playlist,
+} from '@/entities/playlists';
 import { AuthHeaderBuilder, BaseAuthHeaderBuilder } from './auth';
 import { HttpClient, Method } from './http';
 
@@ -8,6 +12,7 @@ export interface PlaylistsClient {
     _name: string,
     _limit: number
   ): Promise<Playlist[]>;
+  createPlaylist(_token: string, _playlist: CreateNewPlaylistDTO): Promise<any>;
 }
 
 export class PlaylistsHTTPClient implements PlaylistsClient {
@@ -50,16 +55,44 @@ export class PlaylistsHTTPClient implements PlaylistsClient {
         )
       );
   }
+
+  async createPlaylist(
+    token: string,
+    playlist: CreateNewPlaylistDTO
+  ): Promise<CreateNewPlaylistResponseDTO> {
+    const authHeader = await this.httpAuthHeaderBuilder.buildHeader(token);
+    return this.httpClient
+      .send({
+        url: `${this.url}/playlists`,
+        method: Method.Post,
+        data: playlist,
+        headers: authHeader,
+      })
+      .then((playlistCreated: any) => {
+        return playlistCreated.data.playlist;
+      });
+  }
 }
 
 export class PlaylistsClientStub implements PlaylistsClient {
   private searchPlaylistResult: Playlist[];
+  private createPlaylistResult: CreateNewPlaylistResponseDTO;
 
-  constructor(result: Playlist[] = []) {
-    this.searchPlaylistResult = result;
+  constructor(
+    searchPlaylistResult: Playlist[] = [],
+    createPlaylistResult: CreateNewPlaylistResponseDTO = {
+      id: '1',
+    }
+  ) {
+    this.searchPlaylistResult = searchPlaylistResult;
+    this.createPlaylistResult = createPlaylistResult;
   }
 
   async searchPlaylists(..._: any[]): Promise<Playlist[]> {
     return this.searchPlaylistResult;
+  }
+
+  async createPlaylist(..._: any[]): Promise<any> {
+    return this.createPlaylistResult;
   }
 }

--- a/src/lib/clients/playlists.ts
+++ b/src/lib/clients/playlists.ts
@@ -12,7 +12,10 @@ export interface PlaylistsClient {
     _name: string,
     _limit: number
   ): Promise<Playlist[]>;
-  createPlaylist(_token: string, _playlist: CreateNewPlaylistDTO): Promise<any>;
+  createPlaylist(
+    _token: string,
+    _playlist: CreateNewPlaylistDTO
+  ): Promise<CreateNewPlaylistResponseDTO>;
 }
 
 export class PlaylistsHTTPClient implements PlaylistsClient {
@@ -68,8 +71,17 @@ export class PlaylistsHTTPClient implements PlaylistsClient {
         data: playlist,
         headers: authHeader,
       })
-      .then((playlistCreated: any) => {
-        return playlistCreated.data.playlist;
+      .then((response: any) => {
+        if (response.status === 201) {
+          return {
+            id: response.data.playlist.id,
+            status: 'CREATED_WITHOUT_ISSUES',
+          };
+        }
+        return {
+          id: response.data.playlist.id,
+          status: 'CREATED_MISSING_ARTISTS',
+        };
       });
   }
 }
@@ -82,6 +94,7 @@ export class PlaylistsClientStub implements PlaylistsClient {
     searchPlaylistResult: Playlist[] = [],
     createPlaylistResult: CreateNewPlaylistResponseDTO = {
       id: '1',
+      status: 'CREATED_WITHOUT_ISSUES',
     }
   ) {
     this.searchPlaylistResult = searchPlaylistResult;

--- a/src/pages/api/playlists/create.test.ts
+++ b/src/pages/api/playlists/create.test.ts
@@ -115,9 +115,10 @@ describe('createCreatePlaylistHandler', () => {
     });
   });
 
-  it('should return backend client results', async () => {
+  it('should return backend client results with 201 status when creation is successfully without issues', async () => {
     const createdPlaylistResponse: CreateNewPlaylistResponseDTO = {
       id: '123',
+      status: 'CREATED_WITHOUT_ISSUES',
     };
     const client = new PlaylistsClientStub();
     vi.spyOn(client, 'createPlaylist').mockResolvedValue(
@@ -133,7 +134,30 @@ describe('createCreatePlaylistHandler', () => {
       message: 'Playlists successfully created',
     };
 
-    expect(response.status).toBeCalledWith(200);
+    expect(response.status).toBeCalledWith(201);
+    expect(response.json).toBeCalledWith(expected);
+  });
+
+  it('should return backend client results with 207 status when creation is successfully with issues', async () => {
+    const createdPlaylistResponse: CreateNewPlaylistResponseDTO = {
+      id: '123',
+      status: 'CREATED_MISSING_ARTISTS',
+    };
+    const client = new PlaylistsClientStub();
+    vi.spyOn(client, 'createPlaylist').mockResolvedValue(
+      createdPlaylistResponse
+    );
+    const response = createMockResponse();
+
+    const handler = createHandler({ client });
+    await handler(createMockRequest(), response);
+
+    const expected = {
+      playlistCreated: createdPlaylistResponse,
+      message: 'Playlist has been created but some artists could not be added',
+    };
+
+    expect(response.status).toBeCalledWith(207);
     expect(response.json).toBeCalledWith(expected);
   });
 

--- a/src/pages/api/playlists/create.test.ts
+++ b/src/pages/api/playlists/create.test.ts
@@ -6,7 +6,10 @@ import {
 } from './create';
 import { PlaylistsClientStub } from '@/lib/clients/playlists';
 import { getToken } from 'next-auth/jwt';
-import { CreateNewPlaylistResponseDTO } from '@/entities/playlists';
+import {
+  CreatedPlaylistStatus,
+  CreateNewPlaylistResponseDTO,
+} from '@/entities/playlists';
 
 vi.mock('next-auth/jwt', () => ({
   getToken: vi.fn(),
@@ -118,7 +121,7 @@ describe('createCreatePlaylistHandler', () => {
   it('should return backend client results with 201 status when creation is successfully without issues', async () => {
     const createdPlaylistResponse: CreateNewPlaylistResponseDTO = {
       id: '123',
-      status: 'CREATED_WITHOUT_ISSUES',
+      status: CreatedPlaylistStatus.OK,
     };
     const client = new PlaylistsClientStub();
     vi.spyOn(client, 'createPlaylist').mockResolvedValue(
@@ -141,7 +144,7 @@ describe('createCreatePlaylistHandler', () => {
   it('should return backend client results with 207 status when creation is successfully with issues', async () => {
     const createdPlaylistResponse: CreateNewPlaylistResponseDTO = {
       id: '123',
-      status: 'CREATED_MISSING_ARTISTS',
+      status: CreatedPlaylistStatus.MISSING_ARTISTS,
     };
     const client = new PlaylistsClientStub();
     vi.spyOn(client, 'createPlaylist').mockResolvedValue(

--- a/src/pages/api/playlists/create.test.ts
+++ b/src/pages/api/playlists/create.test.ts
@@ -26,9 +26,9 @@ describe('createCreatePlaylistHandler', () => {
       playlist: {
         name: 'Chill Vibes',
         description: 'Relaxing music',
-        isPrivate: false,
-        artists: [{ name: 'Artist1' }],
+        isPublic: false,
       },
+      artists: [{ name: 'Artist1' }],
     }
   ): NextApiRequest {
     return { body } as unknown as NextApiRequest;
@@ -96,12 +96,13 @@ describe('createCreatePlaylistHandler', () => {
       playlist: {
         name: 'New Playlist',
         description: 'A fresh playlist',
-        isPrivate: true,
+        isPublic: true,
       },
       artists: [{ name: 'Artist1' }, { name: 'Artist2' }],
     };
     const request = createMockRequest({
-      playlist: { ...playlistData.playlist, artists: playlistData.artists },
+      playlist: playlistData.playlist,
+      artists: playlistData.artists,
     });
     const client = new PlaylistsClientStub();
     vi.spyOn(client, 'createPlaylist');
@@ -112,7 +113,7 @@ describe('createCreatePlaylistHandler', () => {
       playlist: {
         name: playlistData.playlist.name,
         description: playlistData.playlist.description,
-        isPrivate: playlistData.playlist.isPrivate,
+        isPublic: playlistData.playlist.isPublic,
       },
       artists: playlistData.artists,
     });

--- a/src/pages/api/playlists/create.test.ts
+++ b/src/pages/api/playlists/create.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, vi, expect, beforeEach } from 'vitest';
+import { NextApiRequest, NextApiResponse } from 'next';
+import {
+  createCreatePlaylistHandler,
+  CreatePlaylistHandlerParams,
+} from './create';
+import { PlaylistsClientStub } from '@/lib/clients/playlists';
+import { getToken } from 'next-auth/jwt';
+import { CreateNewPlaylistResponseDTO } from '@/entities/playlists';
+
+vi.mock('next-auth/jwt', () => ({
+  getToken: vi.fn(),
+}));
+
+describe('createCreatePlaylistHandler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getToken).mockResolvedValue({ accessToken: 'mocked-token' });
+  });
+
+  function createMockRequest(
+    body: any = {
+      playlist: {
+        name: 'Chill Vibes',
+        description: 'Relaxing music',
+        isPrivate: false,
+        artists: [{ name: 'Artist1' }],
+      },
+    }
+  ): NextApiRequest {
+    return { body } as unknown as NextApiRequest;
+  }
+
+  function createMockResponse(): NextApiResponse {
+    const response = {} as NextApiResponse;
+    response.status = vi.fn().mockReturnValue(response);
+    response.json = vi.fn().mockReturnValue(response);
+    return response;
+  }
+
+  function createHandler(
+    { client }: CreatePlaylistHandlerParams = {
+      client: new PlaylistsClientStub(),
+    }
+  ): (_request: NextApiRequest, _response: NextApiResponse) => Promise<void> {
+    return createCreatePlaylistHandler({ client });
+  }
+
+  it('should return 400 if request body is invalid', async () => {
+    const invalidRequest = createMockRequest({ invalidData: true });
+    const response = createMockResponse();
+
+    await createHandler()(invalidRequest, response);
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.json).toHaveBeenCalled();
+  });
+
+  it('should return 400 if playlist name is missing', async () => {
+    const invalidRequest = createMockRequest({
+      playlist: {
+        description: 'Missing name',
+        isPrivate: false,
+        artists: [{ name: 'Artist1' }],
+      },
+    });
+    const response = createMockResponse();
+
+    await createHandler()(invalidRequest, response);
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.json).toHaveBeenCalled();
+  });
+
+  it('should return 400 if artists array is missing', async () => {
+    const invalidRequest = createMockRequest({
+      playlist: {
+        name: 'Test Playlist',
+        description: 'Missing artists',
+        isPrivate: false,
+      },
+    });
+    const response = createMockResponse();
+
+    await createHandler()(invalidRequest, response);
+
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.json).toHaveBeenCalled();
+  });
+
+  it('should create playlist with the provided data', async () => {
+    const playlistData = {
+      playlist: {
+        name: 'New Playlist',
+        description: 'A fresh playlist',
+        isPrivate: true,
+      },
+      artists: [{ name: 'Artist1' }, { name: 'Artist2' }],
+    };
+    const request = createMockRequest({
+      playlist: { ...playlistData.playlist, artists: playlistData.artists },
+    });
+    const client = new PlaylistsClientStub();
+    vi.spyOn(client, 'createPlaylist');
+
+    await createHandler({ client })(request, createMockResponse());
+
+    expect(client.createPlaylist).toHaveBeenCalledWith('mocked-token', {
+      playlist: {
+        name: playlistData.playlist.name,
+        description: playlistData.playlist.description,
+        isPrivate: playlistData.playlist.isPrivate,
+      },
+      artists: playlistData.artists,
+    });
+  });
+
+  it('should return backend client results', async () => {
+    const createdPlaylistResponse: CreateNewPlaylistResponseDTO = {
+      id: '123',
+    };
+    const client = new PlaylistsClientStub();
+    vi.spyOn(client, 'createPlaylist').mockResolvedValue(
+      createdPlaylistResponse
+    );
+    const response = createMockResponse();
+
+    const handler = createHandler({ client });
+    await handler(createMockRequest(), response);
+
+    const expected = {
+      playlistCreated: createdPlaylistResponse,
+      message: 'Playlists successfully created',
+    };
+
+    expect(response.status).toBeCalledWith(200);
+    expect(response.json).toBeCalledWith(expected);
+  });
+
+  it('should return an error if creation fails', async () => {
+    const client = new PlaylistsClientStub();
+    vi.spyOn(client, 'createPlaylist').mockImplementation(() => {
+      throw new Error('test error');
+    });
+    const response = createMockResponse();
+
+    const handler = createHandler({ client });
+    await handler(createMockRequest(), response);
+
+    expect(response.status).toBeCalledWith(500);
+    expect(response.json).toBeCalledWith({
+      message: 'Unexpected error, cannot create playlist',
+    });
+  });
+
+  it('should return 401 if token is not provided', async () => {
+    vi.mocked(getToken).mockResolvedValue(null);
+    const response = createMockResponse();
+
+    const handler = createHandler();
+    await handler(createMockRequest(), response);
+
+    expect(response.status).toBeCalledWith(401);
+    expect(response.json).toBeCalledWith({
+      message: 'Unauthorized',
+    });
+  });
+});

--- a/src/pages/api/playlists/create.ts
+++ b/src/pages/api/playlists/create.ts
@@ -67,7 +67,15 @@ export function createCreatePlaylistHandler({
         playlistData
       );
 
-      response.status(200).json({
+      if (playlistCreated.status === 'CREATED_MISSING_ARTISTS') {
+        response.status(207).json({
+          playlistCreated,
+          message:
+            'Playlist has been created but some artists could not be added',
+        });
+      }
+
+      response.status(201).json({
         playlistCreated,
         message: 'Playlists successfully created',
       });

--- a/src/pages/api/playlists/create.ts
+++ b/src/pages/api/playlists/create.ts
@@ -4,7 +4,10 @@ import { HttpClient, HttpBaseClient } from '@/lib/clients/http';
 import { PlaylistsClient, PlaylistsHTTPClient } from '@/lib/clients/playlists';
 import { getToken } from 'next-auth/jwt';
 import { BaseAuthHeaderBuilder } from '@/lib/clients/auth';
-import { CreateNewPlaylistResponseDTO } from '@/entities/playlists';
+import {
+  CreatedPlaylistStatus,
+  CreateNewPlaylistResponseDTO,
+} from '@/entities/playlists';
 
 export type CreatePlaylistHandlerParams = {
   client: PlaylistsClient;
@@ -67,7 +70,7 @@ export function createCreatePlaylistHandler({
         playlistData
       );
 
-      if (playlistCreated.status === 'CREATED_MISSING_ARTISTS') {
+      if (playlistCreated.status === CreatedPlaylistStatus.MISSING_ARTISTS) {
         response.status(207).json({
           playlistCreated,
           message:

--- a/src/pages/api/playlists/create.ts
+++ b/src/pages/api/playlists/create.ts
@@ -55,16 +55,16 @@ export function createCreatePlaylistHandler({
 
     const { playlist } = parsedArgs.data;
 
-    try {
-      const playlistData = {
-        playlist: {
-          name: playlist.name,
-          description: playlist.description,
-          isPrivate: playlist.isPrivate || false,
-        },
-        artists: playlist.artists,
-      };
+    const playlistData = {
+      playlist: {
+        name: playlist.name,
+        description: playlist.description,
+        isPrivate: playlist.isPrivate || false,
+      },
+      artists: playlist.artists,
+    };
 
+    try {
       const playlistCreated = await client.createPlaylist(
         token.accessToken,
         playlistData

--- a/src/pages/api/playlists/create.ts
+++ b/src/pages/api/playlists/create.ts
@@ -21,14 +21,14 @@ export type ResponseData = {
 const searchQuerySchema = z.object({
   playlist: z.object({
     name: z.string(),
-    description: z.string().optional(),
-    isPrivate: z.boolean().optional(),
-    artists: z.array(
-      z.object({
-        name: z.string(),
-      })
-    ),
+    description: z.string(),
+    isPublic: z.boolean(),
   }),
+  artists: z.array(
+    z.object({
+      name: z.string(),
+    })
+  ),
 });
 
 export function createCreatePlaylistHandler({
@@ -53,15 +53,11 @@ export function createCreatePlaylistHandler({
       return;
     }
 
-    const { playlist } = parsedArgs.data;
+    const { playlist, artists } = parsedArgs.data;
 
     const playlistData = {
-      playlist: {
-        name: playlist.name,
-        description: playlist.description,
-        isPrivate: playlist.isPrivate || false,
-      },
-      artists: playlist.artists,
+      playlist,
+      artists,
     };
 
     try {

--- a/src/pages/api/playlists/create.ts
+++ b/src/pages/api/playlists/create.ts
@@ -76,6 +76,7 @@ export function createCreatePlaylistHandler({
           message:
             'Playlist has been created but some artists could not be added',
         });
+        return;
       }
 
       response.status(201).json({

--- a/src/pages/api/playlists/create.ts
+++ b/src/pages/api/playlists/create.ts
@@ -1,0 +1,95 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+import { HttpClient, HttpBaseClient } from '@/lib/clients/http';
+import { PlaylistsClient, PlaylistsHTTPClient } from '@/lib/clients/playlists';
+import { getToken } from 'next-auth/jwt';
+import { BaseAuthHeaderBuilder } from '@/lib/clients/auth';
+import { CreateNewPlaylistResponseDTO } from '@/entities/playlists';
+
+export type CreatePlaylistHandlerParams = {
+  client: PlaylistsClient;
+};
+
+export type ResponseData = {
+  message: string;
+  playlistCreated?: CreateNewPlaylistResponseDTO;
+};
+
+const searchQuerySchema = z.object({
+  playlist: z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    isPrivate: z.boolean().optional(),
+    artists: z.array(
+      z.object({
+        name: z.string(),
+      })
+    ),
+  }),
+});
+
+export function createCreatePlaylistHandler({
+  client,
+}: CreatePlaylistHandlerParams) {
+  return async function handler(
+    request: NextApiRequest,
+    response: NextApiResponse<ResponseData>
+  ): Promise<void> {
+    const parsedArgs = searchQuerySchema.safeParse(request.body);
+    if (!parsedArgs.success) {
+      response
+        .status(400)
+        .json({ message: parsedArgs.error.errors[0].message });
+      return;
+    }
+
+    const token = await getToken({ req: request });
+
+    if (!token) {
+      response.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+
+    const { playlist } = parsedArgs.data;
+
+    try {
+      const playlistData = {
+        playlist: {
+          name: playlist.name,
+          description: playlist.description,
+          isPrivate: playlist.isPrivate || false,
+        },
+        artists: playlist.artists,
+      };
+
+      const playlistCreated = await client.createPlaylist(
+        token.accessToken,
+        playlistData
+      );
+
+      response.status(200).json({
+        playlistCreated,
+        message: 'Playlists successfully created',
+      });
+    } catch {
+      response
+        .status(500)
+        .json({ message: 'Unexpected error, cannot create playlist' });
+    }
+  };
+}
+
+const serverHost: string = process.env.SERVER_HOST || 'http://localhost';
+const serverPort: number = parseInt(process.env.SERVER_PORT || '8080');
+const httpClient: HttpClient = new HttpBaseClient();
+const httpAuthHeaderBuilder = new BaseAuthHeaderBuilder();
+const client: PlaylistsClient = new PlaylistsHTTPClient(
+  `${serverHost}:${serverPort}`,
+  httpClient,
+  httpAuthHeaderBuilder
+);
+const createPlaylistHandler: (
+  _request: NextApiRequest,
+  _response: NextApiResponse
+) => void = createCreatePlaylistHandler({ client });
+export default createPlaylistHandler;


### PR DESCRIPTION
# Description
Implement a new API endpoint to create a new playlist.
- Add handling errors
- Add test cases for API endpoint and new method in playlist client

# Testing
- You have to take the cookie from the request using the client app and executing for any GET endpoint from the request in Chrome Devtools.

<img width="553" alt="image" src="https://github.com/user-attachments/assets/a08c7f6a-f646-434c-85f6-1f48d39fd171" />

```
curl --location 'http://localhost:3000/api/playlists/create' \
--header 'Cookie: <NEXT-AUTH-TOKEN>' \
--header 'Content-Type: application/json' \
--data '{
    "playlist": {
        "name": "Test playlist 4",
        "description": "Test description",
        "isPublic": false,
        "artists": [
            { "name": "Holding Absence" },
            { "name": "Attila" },
            { "name": "Polaris" },
            { "name": "Parkway Drive" }
        ]
    }
}'
```