### PR TITLE
feat: FW-100 Add list in success step

### DIFF
--- a/__tests__/generate.test.tsx
+++ b/__tests__/generate.test.tsx
@@ -125,6 +125,15 @@ const customRenderWithProviders = (ui: ReactNode) => {
 };
 
 describe('GeneratePlaylistPage', () => {
+
+  let searchResultArtists = ['Holding Absence'];
+
+  beforeEach(() => {
+    artistsService.searchArtists.mockResolvedValue({
+      artists: searchResultArtists.map(name => ({ name: name, imageUri: null }))
+    });
+  });
+
   it('should render the form with the first step displayed', async () => {
     customRenderWithProviders(<GeneratePlaylistPage {...staticTranslations} />);
 
@@ -251,14 +260,6 @@ describe('GeneratePlaylistPage', () => {
   });
 
   it('should create the new playlist and display the success message', async () => {
-    artistsService.searchArtists.mockResolvedValue({
-      artists: [
-        {
-          name: 'Holding Absence',
-          imageUri: null,
-        },
-      ],
-    });
     playlistsService.createNewPlaylist.mockResolvedValue({
       playlistCreated: {
         id: '123',
@@ -327,14 +328,6 @@ describe('GeneratePlaylistPage', () => {
       .spyOn(navigator.clipboard, 'writeText')
       .mockImplementation(() => Promise.resolve());
 
-    artistsService.searchArtists.mockResolvedValue({
-      artists: [
-        {
-          name: 'Holding Absence',
-          imageUri: null,
-        },
-      ],
-    });
     playlistsService.createNewPlaylist.mockResolvedValue({
       playlistCreated: {
         id: '123',
@@ -386,14 +379,6 @@ describe('GeneratePlaylistPage', () => {
   });
 
   it('should display an error when it tries to submitting the form', async () => {
-    artistsService.searchArtists.mockResolvedValue({
-      artists: [
-        {
-          name: 'Holding Absence',
-          imageUri: null,
-        },
-      ],
-    });
     playlistsService.createNewPlaylist.mockRejectedValue({
       error: 'Error creating playlist',
     });

--- a/__tests__/generate.test.tsx
+++ b/__tests__/generate.test.tsx
@@ -322,11 +322,7 @@ describe('GeneratePlaylistPage', () => {
     });
   });
 
-  it('should copy the URL link into the clipboard when clicking the copy button', async () => {
-    const spyClipboardWriteText = vi
-      .spyOn(navigator.clipboard, 'writeText')
-      .mockImplementation(() => Promise.resolve());
-
+  it('should show the embedded playlist on successful update', async () => {
     customRenderWithProviders(<GeneratePlaylistPage {...staticTranslations} />);
 
     const playlistNameInput = screen.getByLabelText(
@@ -354,21 +350,10 @@ describe('GeneratePlaylistPage', () => {
       const thirdStepContent = screen.getByRole('tabpanel');
       return within(thirdStepContent).getByText(/steps.step3.title/i);
     });
+    const embeddedPlaylist = screen.queryByTitle('Spotify embedded playlist');
 
     expect(thirdStepContentTitle).toBeInTheDocument();
-
-    const copyURLButton = screen.getByRole('button', {
-      name: /steps.step3.copyButton/i,
-    });
-    expect(copyURLButton).toBeInTheDocument();
-
-    userEvent.click(copyURLButton);
-
-    await waitFor(() => {
-      expect(spyClipboardWriteText).toHaveBeenCalledWith(
-        'https://open.spotify.com/playlist/' + createdPlaylistId
-      );
-    });
+    expect(embeddedPlaylist).toHaveAttribute('src', `https://open.spotify.com/embed/playlist/${createdPlaylistId}`);
   });
 
   it('should display an error when it tries to submitting the form', async () => {

--- a/__tests__/generate.test.tsx
+++ b/__tests__/generate.test.tsx
@@ -126,12 +126,12 @@ const customRenderWithProviders = (ui: ReactNode) => {
 
 describe('GeneratePlaylistPage', () => {
 
-  let searchResultArtists = ['Holding Absence'];
+  let searchResultArtists = [{ name: 'Holding Absence', imageUri: null }];
   let createdPlaylistId = '123';
 
   beforeEach(() => {
     artistsService.searchArtists.mockResolvedValue({
-      artists: searchResultArtists.map(name => ({ name: name, imageUri: null }))
+      artists: searchResultArtists.map(artist => ({ name: artist.name, imageUri: artist.imageUri })),
     });
 
     playlistsService.createNewPlaylist.mockResolvedValue({

--- a/__tests__/generate.test.tsx
+++ b/__tests__/generate.test.tsx
@@ -127,10 +127,15 @@ const customRenderWithProviders = (ui: ReactNode) => {
 describe('GeneratePlaylistPage', () => {
 
   let searchResultArtists = ['Holding Absence'];
+  let createdPlaylistId = '123';
 
   beforeEach(() => {
     artistsService.searchArtists.mockResolvedValue({
       artists: searchResultArtists.map(name => ({ name: name, imageUri: null }))
+    });
+
+    playlistsService.createNewPlaylist.mockResolvedValue({
+      playlistCreated: { id: createdPlaylistId },
     });
   });
 
@@ -260,12 +265,6 @@ describe('GeneratePlaylistPage', () => {
   });
 
   it('should create the new playlist and display the success message', async () => {
-    playlistsService.createNewPlaylist.mockResolvedValue({
-      playlistCreated: {
-        id: '123',
-      },
-    });
-
     customRenderWithProviders(<GeneratePlaylistPage {...staticTranslations} />);
 
     const playlistNameInput = screen.getByLabelText(
@@ -328,12 +327,6 @@ describe('GeneratePlaylistPage', () => {
       .spyOn(navigator.clipboard, 'writeText')
       .mockImplementation(() => Promise.resolve());
 
-    playlistsService.createNewPlaylist.mockResolvedValue({
-      playlistCreated: {
-        id: '123',
-      },
-    });
-
     customRenderWithProviders(<GeneratePlaylistPage {...staticTranslations} />);
 
     const playlistNameInput = screen.getByLabelText(
@@ -373,7 +366,7 @@ describe('GeneratePlaylistPage', () => {
 
     await waitFor(() => {
       expect(spyClipboardWriteText).toHaveBeenCalledWith(
-        'https://open.spotify.com/playlist/123'
+        'https://open.spotify.com/playlist/' + createdPlaylistId
       );
     });
   });

--- a/__tests__/generate.test.tsx
+++ b/__tests__/generate.test.tsx
@@ -130,9 +130,7 @@ describe('GeneratePlaylistPage', () => {
   let createdPlaylistId = '123';
 
   beforeEach(() => {
-    artistsService.searchArtists.mockResolvedValue({
-      artists: searchResultArtists.map(artist => ({ name: artist.name, imageUri: artist.imageUri })),
-    });
+    artistsService.searchArtists.mockResolvedValue({ artists: searchResultArtists});
 
     playlistsService.createNewPlaylist.mockResolvedValue({
       playlistCreated: { id: createdPlaylistId },

--- a/locales/ca/generate.json
+++ b/locales/ca/generate.json
@@ -21,7 +21,6 @@
       }
     },
     "navigation": {
-      "finish": "Finalitzar",
       "generate": "Generar",
       "generating": "Generant...",
       "next": "Següent",

--- a/locales/ca/generate.json
+++ b/locales/ca/generate.json
@@ -67,11 +67,9 @@
       "title": "Cerca els artistes"
     },
     "step3": {
-      "copyButton": "Copia URL",
-      "copySuccessButton": "Copiat!",
-      "description": "Obre la llista generada o modificada utilitzant la URL de Spotify",
+      "description": "Visualitza les cançons afegides a a llista",
       "playlisyGeneratedSuccessfully": "Llista generada amb èxit",
-      "title": "Copia la URL"
+      "title": "Visualitza la llista de reproducció"
     }
   }
 }

--- a/locales/en/generate.json
+++ b/locales/en/generate.json
@@ -21,7 +21,6 @@
       }
     },
     "navigation": {
-      "finish": "Finish",
       "generate": "Generate",
       "generating": "Generating...",
       "next": "Next",

--- a/locales/en/generate.json
+++ b/locales/en/generate.json
@@ -67,11 +67,9 @@
       "title": "Search the artists"
     },
     "step3": {
-      "copyButton": "Copy URL",
-      "copySuccessButton": "Copied!",
-      "description": "Open the generated or modified playlist using the Spotify URL",
+      "description": "Visualize the songs added to the playlist",
       "playlisyGeneratedSuccessfully": "Playlist generated successfully",
-      "title": "Copy the URL"
+      "title": "Visualize the playlist"
     }
   }
 }

--- a/locales/es/generate.json
+++ b/locales/es/generate.json
@@ -21,7 +21,6 @@
       }
     },
     "navigation": {
-      "finish": "Finalizar",
       "generate": "Generar",
       "generating": "Generando...",
       "next": "Siguiente",

--- a/locales/es/generate.json
+++ b/locales/es/generate.json
@@ -68,11 +68,9 @@
       "title": "Busca los artistas"
     },
     "step3": {
-      "copyButton": "Copia URL",
-      "copySuccessButton": "Copiada!",
-      "description": "Abre la lista de reproducción generada o modificada usando la URL de Spotify",
+      "description": "Visualiza las canciones añadidas en la lista",
       "playlisyGeneratedSuccessfully": "Lista de reproducción generada con éxito",
-      "title": "Copia la URL"
+      "title": "Visualiza la lista de reproducción"
     }
   }
 }

--- a/src/components/generate/GeneratePlaylistStepper.tsx
+++ b/src/components/generate/GeneratePlaylistStepper.tsx
@@ -7,7 +7,6 @@ import PlaylistSetupForm from '@components/generate/PlaylistSetupForm/PlaylistSe
 import { Button } from '@components/ui/Button';
 import { Stepper, StepList, Step, StepContent } from '@components/ui/Stepper';
 import useTranslation from 'next-translate/useTranslation';
-import Link from 'next/link';
 import { useState } from 'react';
 import { Form } from '@components/ui/Form';
 import { usePlaylistSubmission } from './usePlaylistSubmission';
@@ -114,7 +113,6 @@ const GeneratePlaylistStepper = () => {
   const shouldDisplayBackButton =
     currentStep > 1 && currentStep !== STEPS_COUNT;
   const shouldDisplayNextButton = currentStep === 1;
-  const shouldDisplayFinishButton = currentStep === STEPS_COUNT;
   const shouldDisplaySubmitButton = currentStep === 2;
 
   return (
@@ -173,11 +171,6 @@ const GeneratePlaylistStepper = () => {
                   {isLoading
                     ? t('steps.navigation.generating')
                     : t('steps.navigation.generate')}
-                </Button>
-              )}
-              {shouldDisplayFinishButton && (
-                <Button asChild>
-                  <Link href="/">{t('steps.navigation.finish')}</Link>
                 </Button>
               )}
             </div>

--- a/src/components/generate/GeneratePlaylistStepper.tsx
+++ b/src/components/generate/GeneratePlaylistStepper.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import PlaylistGetUrlLink from '@components/generate/PlaylistGetUrlLink/PlaylistGetUrlLink';
+import PlaylistUpdateReport from '@/components/generate/PlaylistUpdateReport/PlaylistUpdateReport';
 import PlaylistSearchArtistsForm from '@/components/generate/PlaylistSearchArtistsForm/PlaylistSearchArtistsForm';
 import PlaylistSetupForm from '@components/generate/PlaylistSetupForm/PlaylistSetupForm';
 import { Button } from '@components/ui/Button';
@@ -151,7 +151,7 @@ const GeneratePlaylistStepper = () => {
               <PlaylistSearchArtistsForm />
             </StepContent>
             <StepContent stepNumber={3}>
-              <PlaylistGetUrlLink playlistId={playlistId} />
+              <PlaylistUpdateReport playlistId={playlistId} />
             </StepContent>
             <div className="flex justify-end space-x-6 mt-8">
               {shouldDisplayBackButton && (

--- a/src/components/generate/PlaylistUpdateReport/PlaylistOverview.tsx
+++ b/src/components/generate/PlaylistUpdateReport/PlaylistOverview.tsx
@@ -14,7 +14,7 @@ export const PlaylistOverview: FC<PlaylistOverviewProps> = ({
   return (
     <iframe
       src={embedUrl}
-      style={{ borderRadius: '12px' }}
+      className="rounded"
       width="100%"
       height={height}
       allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"

--- a/src/components/generate/PlaylistUpdateReport/PlaylistOverview.tsx
+++ b/src/components/generate/PlaylistUpdateReport/PlaylistOverview.tsx
@@ -1,0 +1,25 @@
+import { FC } from 'react';
+
+interface PlaylistOverviewProps {
+  playlistId: string;
+  height?: number;
+}
+
+export const PlaylistOverview: FC<PlaylistOverviewProps> = ({
+  playlistId,
+  height = 500,
+}) => {
+  const embedUrl = `https://open.spotify.com/embed/playlist/${playlistId}`;
+
+  return (
+    <iframe
+      src={embedUrl}
+      style={{ borderRadius: '12px' }}
+      width="100%"
+      height={height}
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+      loading="lazy"
+      title="Spotify embedded playlist"
+    />
+  );
+};

--- a/src/components/generate/PlaylistUpdateReport/PlaylistUpdateReport.tsx
+++ b/src/components/generate/PlaylistUpdateReport/PlaylistUpdateReport.tsx
@@ -8,7 +8,7 @@ import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 
 const URL_BASE = 'https://open.spotify.com/playlist/';
 
-const PlaylistGetUrlLink = ({
+const PlaylistUpdateReport = ({
   playlistId,
 }: {
   playlistId: string | undefined;
@@ -54,4 +54,4 @@ const PlaylistGetUrlLink = ({
   );
 };
 
-export default PlaylistGetUrlLink;
+export default PlaylistUpdateReport;

--- a/src/components/generate/PlaylistUpdateReport/PlaylistUpdateReport.tsx
+++ b/src/components/generate/PlaylistUpdateReport/PlaylistUpdateReport.tsx
@@ -1,12 +1,6 @@
-import { Button } from '@components/ui/Button';
 import Heading from '@components/ui/Heading';
-import { Input } from '@components/ui/Input';
 import useTranslation from 'next-translate/useTranslation';
-import playlistReadyImage from '@public/playlist-ready.svg';
-import Image from 'next/image';
-import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
-
-const URL_BASE = 'https://open.spotify.com/playlist/';
+import { PlaylistOverview } from '../PlaylistUpdateReport/PlaylistOverview';
 
 const PlaylistUpdateReport = ({
   playlistId,
@@ -14,8 +8,6 @@ const PlaylistUpdateReport = ({
   playlistId: string | undefined;
 }) => {
   const { t } = useTranslation('generate');
-  const { copy, isCopied } = useCopyToClipboard();
-  const urlWithId = `${URL_BASE}${playlistId}`;
   return (
     <>
       <div className="flex flex-col space-y-2">
@@ -28,26 +20,12 @@ const PlaylistUpdateReport = ({
       </div>
       <div className="flex flex-col space-y-6 items-center">
         <div className="flex flex-col space-y-2">
-          <Image
-            src={playlistReadyImage}
-            alt="Playlist ready"
-            className="w-48 h-full"
-          />
           <div className="text-dark-blue font-medium">
             {t('steps.step3.playlisyGeneratedSuccessfully')}
           </div>
         </div>
         <div className="flex w-full md:w-3/4 space-x-2 mt-6">
-          <Input value={urlWithId} readOnly />
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => copy(urlWithId)}
-          >
-            {isCopied
-              ? t('steps.step3.copySuccessButton')
-              : t('steps.step3.copyButton')}
-          </Button>
+          {playlistId && <PlaylistOverview playlistId={playlistId} />}
         </div>
       </div>
     </>


### PR DESCRIPTION
# Description

Replaces url copy step with list visualization.

Next steps:
- Create error page when playlist update fails.
- Add error messages on last step when partial errors occur (e.g. some artists could not be added).

# Testing

https://github.com/user-attachments/assets/f96bb8ac-4aea-4186-b487-08de851e58c5