### PR TITLE
fix: include default headers in fetchService to avoid JSON parsing

### DIFF
--- a/src/pages/api/playlists/create.test.ts
+++ b/src/pages/api/playlists/create.test.ts
@@ -31,7 +31,7 @@ describe('createCreatePlaylistHandler', () => {
       artists: [{ name: 'Artist1' }],
     }
   ): NextApiRequest {
-    return { body: JSON.stringify(body) } as unknown as NextApiRequest;
+    return { body } as unknown as NextApiRequest;
   }
 
   function createMockResponse(): NextApiResponse {

--- a/src/pages/api/playlists/create.ts
+++ b/src/pages/api/playlists/create.ts
@@ -38,7 +38,7 @@ export function createCreatePlaylistHandler({
     request: NextApiRequest,
     response: NextApiResponse<CreatePlaylistResponseData>
   ): Promise<void> {
-    const body = JSON.parse(request.body);
+    const body = request.body;
     const parsedArgs = createNewPlaylistSchema.safeParse(body);
 
     if (!parsedArgs.success) {

--- a/src/services/fetchService.ts
+++ b/src/services/fetchService.ts
@@ -4,7 +4,19 @@ export interface IFetchService {
 
 export class FetchService implements IFetchService {
   async fetchData<T>(url: string, options?: RequestInit): Promise<T> {
-    const response = await fetch(url, options);
+    const defaultHeaders = {
+      'Content-Type': 'application/json',
+    };
+
+    const mergedOptions: RequestInit = {
+      ...options,
+      headers: {
+        ...defaultHeaders,
+        ...options?.headers,
+      },
+    };
+
+    const response = await fetch(url, mergedOptions);
     if (!response.ok) {
       throw new Error(`Error fetching data: ${response.statusText}`);
     }


### PR DESCRIPTION
## Description
Add `'Content-Type': 'application/json'` header to ensure avoid parsing JSONs between UI and API.