### PR TITLE
refactor: [FW-93] use error messages from Zod schema instead

### DIFF
--- a/locales/ca/generate.json
+++ b/locales/ca/generate.json
@@ -10,7 +10,7 @@
         "required": "El nom de la llista és obligatori"
       },
       "playlistSelected": {
-        "required": "Selecciona una llista de reproducció"
+        "required": "Seleccionar una llista de reproducció és obligatori"
       },
       "selectedArtists": {
         "required": "Selecciona com a mínim un artista"

--- a/locales/en/generate.json
+++ b/locales/en/generate.json
@@ -10,7 +10,7 @@
         "required": "The playlist name is required"
       },
       "playlistSelected": {
-        "required": "Select a playlist"
+        "required": "Select a playlist is required"
       },
       "selectedArtists": {
         "required": "Select at least one artist"

--- a/locales/es/generate.json
+++ b/locales/es/generate.json
@@ -10,7 +10,7 @@
         "required": "El nombre de la lista es obligatorio"
       },
       "playlistSelected": {
-        "required": "Selecciona una lista de reproducción"
+        "required": "Seleccionar una lista de reproducción es obligatorio"
       },
       "selectedArtists": {
         "required": "Selecciona al menos un artista"

--- a/src/components/generate/GeneratePlaylistStepper.tsx
+++ b/src/components/generate/GeneratePlaylistStepper.tsx
@@ -31,7 +31,7 @@ const baseSchema = z.object({
 
 const newPlaylistSchema = baseSchema.extend({
   playlistCreationMode: z.literal(PlaylistCreationMode.New),
-  name: z.string().min(1, 'Name is required when creating a new playlist'),
+  name: z.string().min(1, 'steps.errors.name.required'),
   description: z.string().optional(),
   isPublic: z.boolean(),
 });

--- a/src/components/generate/GeneratePlaylistStepper.tsx
+++ b/src/components/generate/GeneratePlaylistStepper.tsx
@@ -26,7 +26,7 @@ export const PlaylistCreationMode = {
 const baseSchema = z.object({
   artists: z
     .array(z.string().min(1))
-    .nonempty('At least one artist is required'),
+    .nonempty('steps.errors.selectedArtists.required'),
 });
 
 const newPlaylistSchema = baseSchema.extend({

--- a/src/components/generate/GeneratePlaylistStepper.tsx
+++ b/src/components/generate/GeneratePlaylistStepper.tsx
@@ -38,10 +38,15 @@ const newPlaylistSchema = baseSchema.extend({
 
 const existingPlaylistSchema = baseSchema.extend({
   playlistCreationMode: z.literal(PlaylistCreationMode.Existing),
-  playlistSelected: z.object({
-    id: z.string().min(1, "Playlist ID can't be empty"),
-    name: z.string(),
-  }),
+  playlistSelected: z
+    .object({
+      id: z.string().min(1),
+      name: z.string(),
+    })
+    .optional()
+    .refine((val) => !!val, {
+      message: 'steps.errors.playlistSelected.required',
+    }),
 });
 
 const formSchema = z.discriminatedUnion('playlistCreationMode', [

--- a/src/components/generate/PlaylistSearchArtistsForm/PlaylistSearchArtistsForm.tsx
+++ b/src/components/generate/PlaylistSearchArtistsForm/PlaylistSearchArtistsForm.tsx
@@ -62,9 +62,9 @@ const PlaylistSearchArtistsForm = () => {
                   placeholder={t('steps.step2.searchPlaceholder')}
                 />
               </FormControl>
-              {errors.artists && (
+              {errors.artists?.message && (
                 <ErrorMessage>
-                  {t('steps.errors.selectedArtists.required')}
+                  {t(errors.artists.message as string)}
                 </ErrorMessage>
               )}
             </FormItem>

--- a/src/components/generate/PlaylistSetupForm/PlaylistSearcher.tsx
+++ b/src/components/generate/PlaylistSetupForm/PlaylistSearcher.tsx
@@ -123,7 +123,7 @@ const PlaylistSearcher = () => {
           </Popover>
           {errors.playlistSelected?.message && (
             <ErrorMessage>
-              {t('steps.errors.playlistSelected.required')}
+              {t(errors.playlistSelected?.message as string)}
             </ErrorMessage>
           )}
         </FormItem>

--- a/src/components/generate/PlaylistSetupForm/PlaylistSetupForm.tsx
+++ b/src/components/generate/PlaylistSetupForm/PlaylistSetupForm.tsx
@@ -87,7 +87,7 @@ const PlaylistSetupForm = () => {
                   </FormControl>
                   {errors.name?.message && (
                     <ErrorMessage>
-                      {t('steps.errors.name.required')}
+                      {t(errors.name?.message as string)}
                     </ErrorMessage>
                   )}
                 </FormItem>


### PR DESCRIPTION
## Description
Replace the error message in the Zod schema for error key translations instead to ensure work with the proper error in each field.