### PR TITLE
fix: fix spurious rendering errors

### DIFF
--- a/src/components/generate/PlaylistUpdateReport/PlaylistOverview.tsx
+++ b/src/components/generate/PlaylistUpdateReport/PlaylistOverview.tsx
@@ -19,7 +19,6 @@ export const PlaylistOverview: FC<PlaylistOverviewProps> = ({
       width="100%"
       height={height}
       allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-      loading="lazy"
       title="Spotify embedded playlist"
     />
   );

--- a/src/components/generate/PlaylistUpdateReport/PlaylistOverview.tsx
+++ b/src/components/generate/PlaylistUpdateReport/PlaylistOverview.tsx
@@ -13,6 +13,7 @@ export const PlaylistOverview: FC<PlaylistOverviewProps> = ({
 
   return (
     <iframe
+      key={playlistId}
       src={embedUrl}
       className="rounded"
       width="100%"


### PR DESCRIPTION
# Description

Adds a key to the iframe to fix the error we often see in prod that forces us to recreate the page in order to see the playlist content. The hypothesis is that the iframe does not load properly due to the missing key property. However, we cannot confirm as we have not been able to reproduce the error locally.

This also removes the iframe lazy loading, as it might play a role in this issue. Since the iframe is the main content of the results page, we see no need to load it lazily, for now.