### PR TITLE
chore: use iframe exponential retry

### DIFF
--- a/src/features/generate/components/playlist-update-report/playlist-overview.tsx
+++ b/src/features/generate/components/playlist-update-report/playlist-overview.tsx
@@ -1,19 +1,43 @@
-import { FC } from 'react';
+import { FC, useEffect, useState, useRef } from 'react';
 
 interface PlaylistOverviewProps {
   playlistId: string;
   height?: number;
+  maxReloads?: number;
+  initialReloadDelayMs?: number;
 }
 
 export const PlaylistOverview: FC<PlaylistOverviewProps> = ({
   playlistId,
   height = 500,
+  maxReloads = 1,
+  initialReloadDelayMs = 1000,
 }) => {
   const embedUrl = `https://open.spotify.com/embed/playlist/${playlistId}`;
 
+  const [reloads, setReloads] = useState(0);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (reloads >= maxReloads) return;
+
+    const nextExpReload = initialReloadDelayMs * Math.pow(2, reloads);
+    timerRef.current = window.setTimeout(() => {
+      setReloads(reloads + 1);
+    }, nextExpReload);
+
+    return () => {
+      if (timerRef.current !== null) {
+        // Clean resources on exit
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [reloads, initialReloadDelayMs, maxReloads]);
+
   return (
     <iframe
-      key={playlistId}
+      key={`${playlistId}-${reloads}`}
       src={embedUrl}
       className="rounded"
       width="100%"


### PR DESCRIPTION
# Description

Allows reloading the playlist iframe through exponential backoff, uses a single reload by default. We see that often the Spotify iframe fails to load at once and gets fixed once we manually refresh the page. This tries to mitigate the issue in prod, which I was unable to reproduce locally.